### PR TITLE
【機械学習・深層学習による自然言語処理入門】gitignoreにapi_keyのファイルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,3 +128,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Others
+api_key.txt


### PR DESCRIPTION
# Summary
- .gitignoreにapi_key.txtを追加
    - API KEYをgithubのレポジトリに載せないようにする